### PR TITLE
V0.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bower_components/
 output/
 .psc-package
 .psc-ide-port
+.spago

--- a/bower.json
+++ b/bower.json
@@ -14,17 +14,16 @@
         "output"
     ],
     "dependencies": {
-        "purescript-console": "^v5.0.0",
-        "purescript-effect": "^v3.0.0",
-        "purescript-either": "^v5.0.0",
-        "purescript-integers": "^v5.0.0",
-        "purescript-lazy": "^v5.0.0",
-        "purescript-lists": "^v6.0.0",
-        "purescript-maybe": "^v5.0.0",
-        "purescript-partial": "^v3.0.0",
-        "purescript-prelude": "^v5.0.0",
-        "purescript-psci-support": "^v5.0.0",
-        "purescript-strings": "^v5.0.0",
-        "purescript-tuples": "^v6.0.0"
+        "purescript-console": "^v6.0.0",
+        "purescript-effect": "^v4.0.0",
+        "purescript-either": "^v6.0.0",
+        "purescript-integers": "^v6.0.0",
+        "purescript-lazy": "^v6.0.0",
+        "purescript-lists": "^v7.0.0",
+        "purescript-maybe": "^v6.0.0",
+        "purescript-partial": "^v4.0.0",
+        "purescript-prelude": "^v6.0.0",
+        "purescript-strings": "^v6.0.0",
+        "purescript-tuples": "^v7.0.0"
     }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210409/packages.dhall sha256:e81c2f2ce790c0e0d79869d22f7a37d16caeb5bd81cfda71d46c58f6199fd33f
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.0-20220527/packages.dhall
+        sha256:15dd8041480502850e4043ea2977ed22d6ab3fc24d565211acde6f8c5152a799
 
 in  upstream

--- a/spago.dhall
+++ b/spago.dhall
@@ -2,7 +2,6 @@
 , dependencies =
   [ "console"
   , "effect"
-  , "psci-support"
   , "strings"
   , "lists"
   , "either"


### PR DESCRIPTION
I ported this to purescript 0.15.   Which only consisted of `spago upgrade-set`, everything compiled and the tests passed.

I bumped the version number to 6.1.1 since no code changes were involved  You might want to want to bump the minor version instead.
